### PR TITLE
Update Hap Decoder to match Hap/HapA/HapQ codec strings

### DIFF
--- a/include/decoders/hap.h
+++ b/include/decoders/hap.h
@@ -8,7 +8,7 @@ namespace decoders {
 
 class Hap : public Decoder {
 public:
-    static bool matches( const std::string &codec ) { return codec == "HapY"; }
+    static bool matches( const std::string &codec ) { return codec == "Hap1" || codec == "Hap5" || codec == "HapY"; }
 
     Hap( int w, int h, AP4_DataBuffer *sample0 );
 


### PR DESCRIPTION
From what I can tell, the mappping is:
- Hap → Hap1
- Hap A → Hap5
- Hap Q → HapY

I haven't been able to test any Hap Q Alpha content so I'm not sure what that string would need to be