### PR TITLE
Implement pause(), change stop() functionality to seek to start

### DIFF
--- a/src/Movie.cpp
+++ b/src/Movie.cpp
@@ -182,13 +182,16 @@ Movie & Movie::play()
 
 Movie & Movie::stop()
 {
-    m_isPlaying = false;
+	pause();
+	seekToStart();
 
 	return *this;
 }
 
 Movie & Movie::pause()
 {
+	m_isPlaying = false;
+
 	return *this;
 }
 


### PR DESCRIPTION
I was wondering why `pause()` didn't seem to do anything, and realize it was unimplemented! And `stop()` was actually really only pausing. This small change makes `pause()` pause, and `stop()` pauses and then seeks to the beginning. I only did some simple testing, but it seems to work.