### PR TITLE
Unbind PIXEL_UNPACK_BUFFER after binding

### DIFF
--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -40,6 +40,7 @@ bool Frame::bufferTexture( GLuint pbo )
 
     copy( m_texData.get(), m_texData.get() + m_texSize, buffer );
     glUnmapBuffer( GL_PIXEL_UNPACK_BUFFER );
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0); // Unbind
     m_pbo = pbo;
 
     if ( m_sync ) glDeleteSync( m_sync );


### PR DESCRIPTION
This fixes intermittent issues with textures elsewhere in my application not being rendered - or at least showing up as black. This could be the fix for #5.